### PR TITLE
Add ROCm/HIP compatibility for AMD GPU support

### DIFF
--- a/src/faithcontour/_C/kernels.cu
+++ b/src/faithcontour/_C/kernels.cu
@@ -727,15 +727,23 @@ std::vector<at::Tensor> aabb_tri_sat_clip_select_cuda(
         centroids  =torch::zeros({K,3}, opts_f);
         areas      =torch::zeros({K},   opts_f);
         AT_DISPATCH_FLOATING_TYPES(aabbs_min.scalar_type(), "sat_centroid_kernel", [&]{
-            #define LAUNCH_CENTROID(MV) sat_centroid_kernel<scalar_t,MV><<<blocks,threads>>>( \
-                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(), \
-                    tris_verts.data_ptr<scalar_t>(), \
-                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(), \
-                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(), \
-                    poly_counts.data_ptr<int>(), centroids.data_ptr<scalar_t>(), areas.data_ptr<scalar_t>(), \
-                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>())
-            if (max_vert==8) { LAUNCH_CENTROID(8); } else { LAUNCH_CENTROID(7); }
-            #undef LAUNCH_CENTROID
+            if (max_vert==8) {
+                sat_centroid_kernel<scalar_t,8><<<blocks,threads>>>(
+                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(),
+                    tris_verts.data_ptr<scalar_t>(),
+                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(),
+                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(),
+                    poly_counts.data_ptr<int>(), centroids.data_ptr<scalar_t>(), areas.data_ptr<scalar_t>(),
+                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>());
+            } else {
+                sat_centroid_kernel<scalar_t,7><<<blocks,threads>>>(
+                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(),
+                    tris_verts.data_ptr<scalar_t>(),
+                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(),
+                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(),
+                    poly_counts.data_ptr<int>(), centroids.data_ptr<scalar_t>(), areas.data_ptr<scalar_t>(),
+                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>());
+            }
         });
     } else { // mode == 2
         poly_counts = torch::zeros({K}, opts_i);
@@ -743,18 +751,29 @@ std::vector<at::Tensor> aabb_tri_sat_clip_select_cuda(
         centroids   = torch::zeros({K, 3}, opts_f);
         areas       = torch::zeros({K},     opts_f);
         AT_DISPATCH_FLOATING_TYPES(aabbs_min.scalar_type(), "sat_clip_kernel", [&]{
-            #define LAUNCH_CLIP(MV) sat_clip_kernel<scalar_t,MV><<<blocks,threads>>>( \
-                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(), \
-                    tris_verts.data_ptr<scalar_t>(), \
-                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(), \
-                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(), \
-                    poly_counts.data_ptr<int>(), \
-                    poly_verts.data_ptr<scalar_t>(), \
-                    centroids.data_ptr<scalar_t>(), \
-                    areas.data_ptr<scalar_t>(), \
-                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>())
-            if (max_vert==8) { LAUNCH_CLIP(8); } else { LAUNCH_CLIP(7); }
-            #undef LAUNCH_CLIP
+            if (max_vert==8) {
+                sat_clip_kernel<scalar_t,8><<<blocks,threads>>>(
+                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(),
+                    tris_verts.data_ptr<scalar_t>(),
+                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(),
+                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(),
+                    poly_counts.data_ptr<int>(),
+                    poly_verts.data_ptr<scalar_t>(),
+                    centroids.data_ptr<scalar_t>(),
+                    areas.data_ptr<scalar_t>(),
+                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>());
+            } else {
+                sat_clip_kernel<scalar_t,7><<<blocks,threads>>>(
+                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(),
+                    tris_verts.data_ptr<scalar_t>(),
+                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(),
+                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(),
+                    poly_counts.data_ptr<int>(),
+                    poly_verts.data_ptr<scalar_t>(),
+                    centroids.data_ptr<scalar_t>(),
+                    areas.data_ptr<scalar_t>(),
+                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>());
+            }
         });
     }
     

--- a/src/faithcontour/_C/kernels.cu
+++ b/src/faithcontour/_C/kernels.cu
@@ -727,14 +727,15 @@ std::vector<at::Tensor> aabb_tri_sat_clip_select_cuda(
         centroids  =torch::zeros({K,3}, opts_f);
         areas      =torch::zeros({K},   opts_f);
         AT_DISPATCH_FLOATING_TYPES(aabbs_min.scalar_type(), "sat_centroid_kernel", [&]{
-            (max_vert==8 ? sat_centroid_kernel<scalar_t,8> : sat_centroid_kernel<scalar_t,7>)
-                <<<blocks,threads>>>(
-                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(),
-                    tris_verts.data_ptr<scalar_t>(),
-                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(),
-                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(),
-                    poly_counts.data_ptr<int>(), centroids.data_ptr<scalar_t>(), areas.data_ptr<scalar_t>(),
-                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>());
+            #define LAUNCH_CENTROID(MV) sat_centroid_kernel<scalar_t,MV><<<blocks,threads>>>( \
+                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(), \
+                    tris_verts.data_ptr<scalar_t>(), \
+                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(), \
+                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(), \
+                    poly_counts.data_ptr<int>(), centroids.data_ptr<scalar_t>(), areas.data_ptr<scalar_t>(), \
+                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>())
+            if (max_vert==8) { LAUNCH_CENTROID(8); } else { LAUNCH_CENTROID(7); }
+            #undef LAUNCH_CENTROID
         });
     } else { // mode == 2
         poly_counts = torch::zeros({K}, opts_i);
@@ -742,17 +743,18 @@ std::vector<at::Tensor> aabb_tri_sat_clip_select_cuda(
         centroids   = torch::zeros({K, 3}, opts_f);
         areas       = torch::zeros({K},     opts_f);
         AT_DISPATCH_FLOATING_TYPES(aabbs_min.scalar_type(), "sat_clip_kernel", [&]{
-            (max_vert==8 ? sat_clip_kernel<scalar_t,8> : sat_clip_kernel<scalar_t,7>)
-                <<<blocks,threads>>>(
-                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(),
-                    tris_verts.data_ptr<scalar_t>(),
-                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(),
-                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(),
-                    poly_counts.data_ptr<int>(),
-                    poly_verts.data_ptr<scalar_t>(),
-                    centroids.data_ptr<scalar_t>(),
-                    areas.data_ptr<scalar_t>(),
-                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>());
+            #define LAUNCH_CLIP(MV) sat_clip_kernel<scalar_t,MV><<<blocks,threads>>>( \
+                    aabbs_min.data_ptr<scalar_t>(), aabbs_max.data_ptr<scalar_t>(), \
+                    tris_verts.data_ptr<scalar_t>(), \
+                    cand_a_idx.data_ptr<long>(), cand_t_idx.data_ptr<long>(), \
+                    K,(scalar_t)eps, hit_mask.data_ptr<bool>(), \
+                    poly_counts.data_ptr<int>(), \
+                    poly_verts.data_ptr<scalar_t>(), \
+                    centroids.data_ptr<scalar_t>(), \
+                    areas.data_ptr<scalar_t>(), \
+                    out_a_idx.data_ptr<long>(), out_t_idx.data_ptr<long>())
+            if (max_vert==8) { LAUNCH_CLIP(8); } else { LAUNCH_CLIP(7); }
+            #undef LAUNCH_CLIP
         });
     }
     

--- a/src/faithcontour/api.py
+++ b/src/faithcontour/api.py
@@ -9,7 +9,10 @@ from .ops import (
 from .utils.mesh import *
 import time
 import einops as eins
-from torch_scatter import scatter_mean, scatter_max, scatter_sum, scatter_min, scatter_softmax
+try:
+    from torch_scatter import scatter_mean, scatter_max, scatter_sum, scatter_min, scatter_softmax
+except ImportError:
+    from .torch_scatter_compat import scatter_mean, scatter_max, scatter_sum, scatter_min, scatter_softmax
 import cubvh
 
 @torch.no_grad()

--- a/src/faithcontour/decoder.py
+++ b/src/faithcontour/decoder.py
@@ -9,7 +9,10 @@ from typing import Dict, Tuple, Optional
 from dataclasses import dataclass
 
 from atom3d.grid import OctreeIndexer, CubeGrid
-from torch_scatter import scatter_max
+try:
+    from torch_scatter import scatter_max
+except ImportError:
+    from .torch_scatter_compat import scatter_max
 
 
 @dataclass

--- a/src/faithcontour/qef_solver.py
+++ b/src/faithcontour/qef_solver.py
@@ -5,7 +5,10 @@ Provides both standard and differentiable versions.
 """
 
 import torch
-from torch_scatter import scatter_sum, scatter_mean
+try:
+    from torch_scatter import scatter_sum, scatter_mean
+except ImportError:
+    from .torch_scatter_compat import scatter_sum, scatter_mean
 from typing import Tuple, Optional
 
 

--- a/src/faithcontour/segment_ops.py
+++ b/src/faithcontour/segment_ops.py
@@ -120,7 +120,10 @@ def compute_edge_flux_sign(
     if valid_indices.numel() > 0:
         # For edges with multiple crossings, use the one with minimal |dot|
         # (most perpendicular to the surface)
-        from torch_scatter import scatter_min
+        try:
+            from torch_scatter import scatter_min
+        except ImportError:
+            from .torch_scatter_compat import scatter_min
         
         _, best_idx = scatter_min(dots.abs(), valid_indices, dim_size=E)
         

--- a/src/faithcontour/torch_scatter_compat.py
+++ b/src/faithcontour/torch_scatter_compat.py
@@ -1,0 +1,81 @@
+"""
+Drop-in replacement for torch_scatter using PyTorch native ops.
+Works on both CUDA and ROCm without needing the torch_scatter C++ extension.
+"""
+import torch
+
+
+def scatter_sum(src, index, dim=0, dim_size=None, fill_value=0):
+    if dim_size is None:
+        dim_size = int(index.max()) + 1
+    shape = list(src.shape)
+    shape[dim] = dim_size
+    out = src.new_full(shape, fill_value)
+    idx = index
+    for _ in range(src.dim() - 1):
+        idx = idx.unsqueeze(-1)
+    idx = idx.expand_as(src)
+    return out.scatter_add_(dim, idx, src)
+
+
+def scatter_mean(src, index, dim=0, dim_size=None, fill_value=0):
+    s = scatter_sum(src, index, dim=dim, dim_size=dim_size, fill_value=0)
+    ones = src.new_ones(src.shape)
+    count = scatter_sum(ones, index, dim=dim, dim_size=dim_size, fill_value=0)
+    count = count.clamp_min(1)
+    return s / count
+
+
+def scatter_max(src, index, dim=0, dim_size=None, fill_value=float('-inf')):
+    if dim_size is None:
+        dim_size = int(index.max()) + 1
+    shape = list(src.shape)
+    shape[dim] = dim_size
+    out = src.new_full(shape, fill_value)
+    arg = index.new_full(shape, -1)
+    idx = index
+    for _ in range(src.dim() - 1):
+        idx = idx.unsqueeze(-1)
+    idx = idx.expand_as(src)
+    out.scatter_reduce_(dim, idx, src, reduce='amax', include_self=False)
+    mask = out != fill_value
+    arange = torch.arange(src.size(dim), device=src.device)
+    dim_shape = [1] * src.dim()
+    dim_shape[dim] = -1
+    arange = arange.view(dim_shape).expand_as(src)
+    arg.scatter_reduce_(dim, idx, arange, reduce='amax', include_self=False)
+    return out, arg
+
+
+def scatter_min(src, index, dim=0, dim_size=None, fill_value=float('inf')):
+    if dim_size is None:
+        dim_size = int(index.max()) + 1
+    shape = list(src.shape)
+    shape[dim] = dim_size
+    out = src.new_full(shape, fill_value)
+    arg = index.new_full(shape, -1)
+    idx = index
+    for _ in range(src.dim() - 1):
+        idx = idx.unsqueeze(-1)
+    idx = idx.expand_as(src)
+    out.scatter_reduce_(dim, idx, src, reduce='amin', include_self=False)
+    arange = torch.arange(src.size(dim), device=src.device)
+    dim_shape = [1] * src.dim()
+    dim_shape[dim] = -1
+    arange = arange.view(dim_shape).expand_as(src)
+    arg.scatter_reduce_(dim, idx, arange, reduce='amin', include_self=False)
+    return out, arg
+
+
+def scatter_softmax(src, index, dim=0, dim_size=None):
+    if dim_size is None:
+        dim_size = int(index.max()) + 1
+    max_val, _ = scatter_max(src, index, dim=dim, dim_size=dim_size)
+    idx = index
+    for _ in range(src.dim() - 1):
+        idx = idx.unsqueeze(-1)
+    idx_exp = idx.expand_as(src)
+    src_centered = src - max_val.gather(dim, idx_exp)
+    exp_src = src_centered.exp()
+    sum_exp = scatter_sum(exp_src, index, dim=dim, dim_size=dim_size)
+    return exp_src / sum_exp.gather(dim, idx_exp).clamp_min(1e-12)


### PR DESCRIPTION
## Summary

Enable FaithC to run on AMD GPUs with ROCm/HIP. Three changes, all backward-compatible with CUDA.

### Changes

1. **Fix hipify kernel launch parsing** (`src/faithcontour/_C/kernels.cu`)
   - Root cause: hipify mangles ternary+template kernel launch expressions like `(cond ? kernel<T,8> : kernel<T,7>)<<<blocks,threads>>>(...)`, producing invalid HIP code
   - Fix: replace with explicit `if/else` branches — cleaner and works on both CUDA and HIP

2. **Add `torch_scatter` fallback using PyTorch native ops** (`src/faithcontour/torch_scatter_compat.py` + 4 files)
   - Root cause: `torch_scatter` C++ extension fails to compile on ROCm 6.4 due to `__shfl_up` overload ambiguity with `c10::Half`
   - Fix: pure-PyTorch reimplementation of `scatter_sum/mean/max/min/softmax` using `torch.scatter_add_` and `torch.scatter_reduce_`; original `torch_scatter` is used when available via `try/except` fallback

### Tested on
- GPU: AMD Instinct MI300X
- ROCm: 6.4.3
- PyTorch: 2.6.0
- Docker: `rocm/pytorch:rocm6.4.3_ubuntu24.04_py3.12_pytorch_release_2.6.0`

### Results

```
python demo.py -r 64     # icosphere: 0.317s total
python demo.py -p assets/examples/pirateship.glb -r 256  # 243K verts: 1.434s total
```

| Model | Input | Resolution | Encode | Decode | Output |
|-------|-------|-----------|--------|--------|--------|
| icosphere | 12 verts / 20 faces | 64 | 0.265s | 0.052s | 17,984 verts / 35,964 faces |
| pirateship | 243,652 verts / 83,364 faces | 256 | 1.368s | 0.065s | 192,953 verts / 387,550 faces |

### Notes
- All changes are backward-compatible — CUDA users are unaffected
- `torch_scatter_compat.py` is a fallback only; when `torch_scatter` is installed, the original C++ version is used
- atom3d JIT compilation also works on ROCm after a one-line flag fix  https://github.com/Luo-Yihao/Atom3d/issues/3